### PR TITLE
Use image name instead of repo name

### DIFF
--- a/.github/workflows/template-docker-build.yaml
+++ b/.github/workflows/template-docker-build.yaml
@@ -202,9 +202,9 @@ jobs:
           committer: Github Actions <infra@demarque.com>
           author: Github Actions <infra@demarque.com>
           branch: deploy/${{ inputs.TARGET_ENV }}/${{ inputs.GITHUB_SHA }}
-          commit-message: "chore: ${{ inputs.TARGET_ENV }} - deploy ${{ inputs.REPOSITORY_NAME }} ${{ inputs.GITHUB_SHA }}"
-          title: ${{ inputs.TARGET_ENV }} - deploy ${{ inputs.REPOSITORY_NAME }} ${{ inputs.GITHUB_SHA }}
-          body: ${{ inputs.TARGET_ENV }} - deploy ${{ inputs.REPOSITORY_NAME }} ${{ inputs.GITHUB_SHA }}
+          commit-message: "chore: ${{ inputs.TARGET_ENV }} - deploy ${{ inputs.IMAGE }} ${{ inputs.GITHUB_SHA }}"
+          title: ${{ inputs.TARGET_ENV }} - deploy ${{ inputs.IMAGE }} ${{ inputs.GITHUB_SHA }}
+          body: ${{ inputs.TARGET_ENV }} - deploy ${{ inputs.IMAGE }} ${{ inputs.GITHUB_SHA }}
           labels: automerge
 
   finalize:


### PR DESCRIPTION
in order to better support mono repos.

example:
- https://github.com/demarque/demarque-infra/commit/b9b961b8852d1c2c8d4a38596f91c0bad5a26faa
- https://github.com/demarque/demarque-infra/commit/f1489594bb60776dde14ddf3ab692cd370f4f5da